### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       Configuration: Release
       PfxBase64: ${{ secrets.BASE64_ENCODED_PFX }}
       PfxKey: ${{ secrets.PFX_KEY }}
-      SiteUrl: ${{ github.event.inputs.serverUrl }}
+      ServerUrl: ${{ github.event.inputs.serverUrl }}
 
     steps:
     - name: Checkout
@@ -51,11 +51,11 @@ jobs:
       with:
         fetch-depth: 0
 
-    # Decode the base 64 encoded pfx and save the Signing_Certificate
+    # Test the Server URL to make sure it's valid
     - name: Check Server URL Format
       run: |
         $Result = ""
-        if (![System.Uri]::TryCreate($env:SiteUrl, [System.UriKind]::Absolute, [ref] $Result)) {
+        if (![System.Uri]::TryCreate($env:ServerUrl, [System.UriKind]::Absolute, [ref] $Result)) {
             throw "Server URL is not in the correct format.  It should be fully qualified with scheme and host (e.g. https://app.remotely.one)."
         }
         
@@ -113,7 +113,7 @@ jobs:
     - name: Run Publish script
       shell: powershell
       run: |
-        .\Utilities\Publish.ps1 -CertificatePath "$env:GITHUB_WORKSPACE\GitHubActionsWorkflow.pfx" -CertificatePassword $env:PfxKey -Hostname $env:SiteUrl -CurrentVersion $env:CurrentVersion -RID linux-x64 -OutDir "$env:GITHUB_WORKSPACE\publish"
+        .\Utilities\Publish.ps1 -CertificatePath "$env:GITHUB_WORKSPACE\GitHubActionsWorkflow.pfx" -CertificatePassword $env:PfxKey -Hostname $env:ServerUrl -CurrentVersion $env:CurrentVersion -RID linux-x64 -OutDir "$env:GITHUB_WORKSPACE\publish"
         
     # Upload build artifact to be deployed from Ubuntu runner
     - name: Upload build artifact
@@ -124,4 +124,7 @@ jobs:
 
     # Remove the pfx
     - name: Remove the pfx
-      run: Remove-Item -path "$env:GITHUB_WORKSPACE\GitHubActionsWorkflow.pfx"
+      run: |
+        if (Test-Path "$env:GITHUB_WORKSPACE\GitHubActionsWorkflow.pfx") {
+          Remove-Item -path "$env:GITHUB_WORKSPACE\GitHubActionsWorkflow.pfx"
+        }


### PR DESCRIPTION
**Important:** I realize Remotely is currently lacking in unit and integration tests.  I was pretty newb when I wrote a lot of the foundational code, and I haven't had time to refactor and restructure.

I'd like to start changing that, though. Enough people are starting to depend on Remotely that I want to make sure it's maintainable and lives on.  So I need every PR to include automated tests that prove the new functionality is working.

If you have the time and the desire, it would also be incredibly helpful if you included some new tests against services touched by your changes.  I know that this is my mess you're cleaning up, so I thank you wholeheartedly for your help.  The people who use Remotely appreciate it too. :)

*Delete the above and add your PR comments here and delete the above.*


---

Please read the following.  Do not delete below this line.

---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to me (Jared Goodwin) so that I retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that I'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Jared Goodwin, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
